### PR TITLE
Submitting null byte chars causes the user_login_failed code to crash

### DIFF
--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -94,8 +94,9 @@ class AxesDatabaseHandler(AxesHandler):  # pylint: disable=too-many-locals
             request.axes_path_info,
         )
 
-        get_data = get_query_str(request.GET)
-        post_data = get_query_str(request.POST)
+        # This replaces null byte chars that crash saving failures, meaning an attacker doesn't get locked out.
+        get_data = get_query_str(request.GET).replace('\0', '0x00')
+        post_data = get_query_str(request.POST).replace('\0', '0x00')
 
         if self.is_whitelisted(request, credentials):
             log.info("AXES: Login failed from whitelisted client %s.", client_str)


### PR DESCRIPTION
Submitting null byte chars like in the post data causes the save to database crash with the following:

/lib/python3.7/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
ValueError: A string literal cannot contain NUL (0x00) characters.

I propose replacing these to something more palatable to the django ORM, and allowing axes to continue its work and block users with multiple failed login attempts that contain NUL characters.